### PR TITLE
add missing import in header_only_packages.rst

### DIFF
--- a/tutorial/creating_packages/other_types_of_packages/header_only_packages.rst
+++ b/tutorial/creating_packages/other_types_of_packages/header_only_packages.rst
@@ -138,6 +138,7 @@ We have the same header-only library that sums two numbers, but now we have this
     import os
     from conan import ConanFile
     from conan.tools.files import copy
+    from conan.tools.build import check_min_cppstd
     from conan.tools.cmake import cmake_layout, CMake
 
 


### PR DESCRIPTION
There's a missing import when looking at the header-only packages with test.